### PR TITLE
Fix deprecation warnings coming with Python 3.7

### DIFF
--- a/editorconfig/fnmatch.py
+++ b/editorconfig/fnmatch.py
@@ -178,7 +178,7 @@ def translate(pat, nested=False):
                 num_range = NUMERIC_RANGE.match(pat[index:pos])
                 if num_range:
                     numeric_groups.append(map(int, num_range.groups()))
-                    result += "([+-]?\d+)"
+                    result += r"([+-]?\d+)"
                 else:
                     inner_result, inner_groups = translate(pat[index:pos],
                                                            nested=True)
@@ -216,5 +216,5 @@ def translate(pat, nested=False):
         else:
             is_escaped = False
     if not nested:
-        result += '\Z(?ms)'
+        result = r'(?s)%s\Z' % result
     return result, numeric_groups


### PR DESCRIPTION
When running tests in a clean repo (i.e., no `*.pyc` files) with all
Python warnings enabled (via `export PYTHONWARNINGS=all`), tests failed
due to the following deprecation warnings:
```
/home/yen/Projects/editorconfig-core-py/editorconfig/fnmatch.py:181: DeprecationWarning: invalid escape sequence \d
  result += "([+-]?\d+)"
/home/yen/Projects/editorconfig-core-py/editorconfig/fnmatch.py:219: DeprecationWarning: invalid escape sequence \Z
  result += '\Z(?ms)'
/home/yen/Projects/editorconfig-core-py/editorconfig/fnmatch.py:90: DeprecationWarning: Flags not at the start of the expression '.*[^/]*/a[^/]*e\\.c\\Z' (truncated)
  regex = re.compile(res)
/home/yen/Projects/editorconfig-core-py/editorconfig/fnmatch.py:90: DeprecationWarning: Flags not at the start of the expression '/home/yen/Projects/e' (truncated)
  regex = re.compile(res)
```

These two changes fix them. Note that the second change is backported
from [1]

[1] https://github.com/python/cpython/commit/bd48d27944453ad83d3ce37b2c867fa0d59a1c15#diff-b62de5c6bce57a277ae7bc60324011ec