### PR TITLE
setup.py: read version without installing

### DIFF
--- a/editorconfig/__init__.py
+++ b/editorconfig/__init__.py
@@ -1,8 +1,7 @@
 """EditorConfig Python Core"""
 
 from editorconfig.versiontools import join_version
-
-VERSION = (0, 12, 2, "final")
+from editorconfig.version import VERSION
 
 __all__ = ['get_properties', 'EditorConfigError', 'exceptions']
 

--- a/editorconfig/version.py
+++ b/editorconfig/version.py
@@ -1,0 +1,1 @@
+VERSION = (0, 12, 3, "alpha")

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
+import os
 from setuptools import setup
 
-import editorconfig
+# Read the version
+g = {}
+with open(os.path.join("editorconfig", "version.py"), "rt") as fp:
+    exec(fp.read(), g)
+    v = g['VERSION']
+    version = ".".join((str(x) for x in v[:3]))
+    if v[3] != "final":
+        version += "-" + v[3]
 
 setup(
     name='EditorConfig',
-    version=editorconfig.__version__,
+    version=version,
     author='EditorConfig Team',
     packages=['editorconfig'],
     url='http://editorconfig.org/',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ g = {}
 with open(os.path.join("editorconfig", "version.py"), "rt") as fp:
     exec(fp.read(), g)
     v = g['VERSION']
-    version = ".".join((str(x) for x in v[:3]))
+    version = ".".join(str(x) for x in v[:3])
     if v[3] != "final":
         version += "-" + v[3]
 


### PR DESCRIPTION
the version read by `setup.py` shouldn't need the module to be already installed which create a :chicken:  and :egg: problem