### PR TITLE
Fix fnmatch adjacent nested curly braces

### DIFF
--- a/editorconfig/fnmatch.py
+++ b/editorconfig/fnmatch.py
@@ -28,7 +28,7 @@ _cache = {}
 LEFT_BRACE = re.compile(
     r"""
 
-    (?: ^ | [^\\] )     # Beginning of string or a character besides "\"
+    (?<! \\ )           # Not preceded by "\"
 
     \{                  # "{"
 
@@ -38,7 +38,7 @@ LEFT_BRACE = re.compile(
 RIGHT_BRACE = re.compile(
     r"""
 
-    (?: ^ | [^\\] )     # Beginning of string or a character besides "\"
+    (?<! \\ )           # Not preceded by "\"
 
     \}                  # "}"
 


### PR DESCRIPTION
If an fnmatch expression had adjacent nested curly braces, the braces would be treated as literals.  For example:

```py
translate('{a,{b,c}}') == '(?s)\\{a\\,\\{b\\,c\\}\\}\\Z'
translate('{{a,b},c}') == '(?s)\\{\\{a\\,b\\}\\,c\\}\\Z'
```

They should be translated as:

```py
translate('{a,{b,c}}') == '(?s)(?:a|(?:b|c))\\Z'
translate('{{a,b},c}') == '(?s)(?:(?:a|b)|c)\\Z'
```

This can occur when matching a mix of file names and extensions.  For example, I encountered the issue for `{CMakeLists.txt,*.{c,cmake,sh}}`.

The issue occurs because `LEFT_BRACE` and `RIGHT_BRACE` include the preceding character in the match, which causes the match to skip the second adjacent curly brace, which causes the match count to differ.  To avoid this, use a zero-width assertion (negative look-behind in this case).

Note: This makes adjacent nested curly braces behave the same as editorconfig-core-c.

Thanks for considering,
Kevin