### PR TITLE
Move the most of metadata into `setup.cfg` supported since Dec 2015.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42.2"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,29 @@
+[metadata]
+name = EditorConfig
+author = EditorConfig Team
+license = PSF-2.0
+description = EditorConfig File Locator and Interpreter for Python
+url = https://editorconfig.org/
+long_description = file: README.rst
+classifiers =
+    License :: OSI Approved :: Python Software Foundation License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: PyPy
+project_urls =
+    Source Code = https://github.com/editorconfig/editorconfig-core-py
+    Bug Tracker = https://github.com/editorconfig/editorconfig-core-py/issues
+
+[options]
+packages = editorconfig
+
+[options.entry_points]
+console_scripts =
+    editorconfig = editorconfig.__main__:main

--- a/setup.py
+++ b/setup.py
@@ -10,35 +10,5 @@ with open(os.path.join("editorconfig", "version.py"), "rt") as fp:
     if v[3] != "final":
         version += "-" + v[3]
 
-setup(
-    name='EditorConfig',
-    version=version,
-    author='EditorConfig Team',
-    packages=['editorconfig'],
-    url='http://editorconfig.org/',
-    project_urls = {
-        "Source Code": "https://github.com/editorconfig/editorconfig-core-py",
-        "Bug Tracker": "https://github.com/editorconfig/editorconfig-core-py/issues",
-    },
-    license='python',
-    description='EditorConfig File Locator and Interpreter for Python',
-    long_description=open('README.rst').read(),
-    entry_points = {
-        'console_scripts': [
-            'editorconfig = editorconfig.__main__:main',
-        ]
-    },
-    classifiers=[
-        'License :: OSI Approved :: Python Software Foundation License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: Implementation :: PyPy',
-    ],
-)
+if __name__ == "__main__":
+    setup(version=version)


### PR DESCRIPTION
Requires #43
A preparation step for #45.
Also allows users of Python 2.7-3.4 to build a wheel using versions of `setuptools` supporting these versions of Python.

Also we can (and **should**) get rid of version calculation in Python code (`setuptools` can read version from sources itself without execution of code from the package), but it can be done in a separate commit.