### PR TITLE
Require CMake 3.16.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # To perform the test, run `cmake .` at the root of the project tree followed
 # by ctest .
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.16.3)
 
 # Do not check any compiler
 project(editorconfig-core-py NONE)


### PR DESCRIPTION
CMake warns that versions below 3.5 may get unsupported soon.

Bump min requirement to 3.16.3, which is what Ubuntu 20.04 has.