### PR TITLE
Remove Python 3.14 DeprecationWarning: codecs.open() is deprecated.

### DIFF
--- a/editorconfig/ini.py
+++ b/editorconfig/ini.py
@@ -96,7 +96,7 @@ class EditorConfigParser(object):
     def read(self, filename: str) -> None:
         """Read and parse single EditorConfig file"""
         try:
-            with open(filename, encoding='utf-8', mode='r') as fp:
+            with open(filename, mode='r') as fp:
                 self._read(fp, filename)
         except OSError:
             return


### PR DESCRIPTION
Will close https://github.com/editorconfig/editorconfig-core-py/issues/96